### PR TITLE
Fix eggplant damaging chickens when consumed

### DIFF
--- a/src/main/java/com/github/namikon/angermod/config/FriendlyAnimalRevengeConfig.java
+++ b/src/main/java/com/github/namikon/angermod/config/FriendlyAnimalRevengeConfig.java
@@ -17,18 +17,34 @@ public final class FriendlyAnimalRevengeConfig {
     public static int revengeRadius;
 
     @Config.Comment("If the food eaten by the player contains these keywords, all PIGS around will become angry (or flee)")
-    @Config.DefaultStringList({ "pork" })
+    @Config.DefaultStringList({ "pork", "bacon", "ham" })
     public static String[] pigFoodTrigger;
+
+    @Config.Comment("Keywords to exclude from pig food triggers")
+    @Config.DefaultStringList({ "hamburger" })
+    public static String[] pigFoodExclusions;
 
     @Config.Comment("If the food eaten by the player contains these keywords, all COWS around will become angry (or flee)")
     @Config.DefaultStringList({ "beef" })
     public static String[] cowFoodTrigger;
 
+    @Config.Comment("Keywords to exclude from cow food triggers")
+    @Config.DefaultStringList({})
+    public static String[] cowFoodExclusions;
+
     @Config.Comment("If the food eaten by the player contains these keywords, all CHICKENS around will become angry (or flee)")
-    @Config.DefaultStringList({ "chicken", "egg" })
+    @Config.DefaultStringList({ "chicken", "egg", "wing" })
     public static String[] chickenFoodTrigger;
 
+    @Config.Comment("Keywords to exclude from chicken food triggers")
+    @Config.DefaultStringList({ "eggplant" })
+    public static String[] chickenFoodExclusions;
+
     @Config.Comment("If the food eaten by the player contains these keywords, all SHEEP around will become angry (or flee)")
-    @Config.DefaultStringList({ "mutton" })
+    @Config.DefaultStringList({ "mutton", "lamb" })
     public static String[] sheepFoodTrigger;
+
+    @Config.Comment("Keywords to exclude from sheep food triggers")
+    @Config.DefaultStringList({})
+    public static String[] sheepFoodExclusions;
 }

--- a/src/main/java/com/github/namikon/angermod/events/EatCookedAnimalsEvent.java
+++ b/src/main/java/com/github/namikon/angermod/events/EatCookedAnimalsEvent.java
@@ -23,16 +23,46 @@ public final class EatCookedAnimalsEvent {
 
         String itemName = event.item.getUnlocalizedName();
 
-        tryTriggerAnimals(FriendlyAnimalRevengeConfig.pigFoodTrigger, itemName, player, EntityPig.class);
-        tryTriggerAnimals(FriendlyAnimalRevengeConfig.cowFoodTrigger, itemName, player, EntityCow.class);
-        tryTriggerAnimals(FriendlyAnimalRevengeConfig.chickenFoodTrigger, itemName, player, EntityChicken.class);
-        tryTriggerAnimals(FriendlyAnimalRevengeConfig.sheepFoodTrigger, itemName, player, EntitySheep.class);
+        tryTriggerAnimals(
+                FriendlyAnimalRevengeConfig.pigFoodTrigger,
+                FriendlyAnimalRevengeConfig.pigFoodExclusions,
+                itemName,
+                player,
+                EntityPig.class);
+        tryTriggerAnimals(
+                FriendlyAnimalRevengeConfig.cowFoodTrigger,
+                FriendlyAnimalRevengeConfig.cowFoodExclusions,
+                itemName,
+                player,
+                EntityCow.class);
+        tryTriggerAnimals(
+                FriendlyAnimalRevengeConfig.chickenFoodTrigger,
+                FriendlyAnimalRevengeConfig.chickenFoodExclusions,
+                itemName,
+                player,
+                EntityChicken.class);
+        tryTriggerAnimals(
+                FriendlyAnimalRevengeConfig.sheepFoodTrigger,
+                FriendlyAnimalRevengeConfig.sheepFoodExclusions,
+                itemName,
+                player,
+                EntitySheep.class);
     }
 
-    private static void tryTriggerAnimals(String[] triggers, String item, EntityPlayer player,
+    private static void tryTriggerAnimals(String[] triggers, String[] exclusions, String item, EntityPlayer player,
             Class<? extends Entity> filter) {
-        for (String s : triggers) {
-            if (item.contains(s)) {
+        for (String trigger : triggers) {
+            if (!item.contains(trigger)) continue;
+
+            boolean excluded = false;
+            for (String exclusion : exclusions) {
+                if (item.contains(exclusion)) {
+                    excluded = true;
+                    break;
+                }
+            }
+
+            if (!excluded) {
                 damageEntitiesInRange(player, filter);
                 return;
             }


### PR DESCRIPTION
Fixes: GTNewHorizons/GT-New-Horizons-Modpack#24940
Fixed substring matching causing `egg` trigger to match `eggplant`

Added `bacon` and `ham` to pig triggers
Added `wing` to chicken triggers
Added `lamb` to sheep triggers

Excludes `hamburger` from pig triggers
Excludes `eggplant` from chicken triggers

Tested in full pack